### PR TITLE
Provide support for Symfony ^6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '7.4'
-          - '8.0'
-          - '8.1'
           - '8.2'
+          - '8.3'
+          - '8.4'
         composer:
           - ''
           - '--prefer-lowest'

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "keywords": [ "propel", "behavior", "event dispatcher", "event" ],
     "license": "MIT",
     "require": {
-        "symfony/event-dispatcher": "^4.3|^5.0",
+        "php": ">=8.2",
+        "symfony/event-dispatcher": "^5.4|^6.0",
         "dayspring-tech/propel1": "^1.8"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=8.2",
         "symfony/event-dispatcher": "^5.4|^6.0",
-        "dayspring-tech/propel1": "^1.8"
+        "dayspring-tech/propel1": "^1.8|^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~8.5.33|^9.0"


### PR DESCRIPTION
- Provide support for Symfony ^6.0
- Change required PHP version to >=8.2
- Allow for either dayspring-tech/propel1 ^1.0 or ^2.0